### PR TITLE
Fix LQI display

### DIFF
--- a/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
@@ -66,7 +66,7 @@ STATE_SENSORS = [
   {
     "name": "Smart Meter IHD HAN LQI",
     "device_class": None,
-    "unit_of_measurement": PERCENTAGE,
+    "unit_of_measurement": None,
     "state_class": SensorStateClass.MEASUREMENT,
     "entity_category": EntityCategory.DIAGNOSTIC,
     "icon": "mdi:wifi-strength-outline",


### PR DESCRIPTION
LQI isn't a percentage. Algorithm used to calculate it is Zigbee stack specific. The Zigbee stack inside the Glowmarkt IHD can return values over 100. 

"han":{"rssi":-66,"status":"joined","lqi":136}