### PR TITLE
Fix gas cost type error

### DIFF
--- a/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
@@ -253,8 +253,8 @@ GAS_SENSORS = [
     "unit_of_measurement": "GBP",
     "state_class": SensorStateClass.TOTAL_INCREASING,
     "icon": "mdi:cash",
-    "func": lambda js : round(js['gasmeter']['energy']['import']['price']['standingcharge'] + \
-       (js['gasmeter']['energy']['import']['day'] * js['gasmeter']['energy']['import']['price']['unitrate']), 2),
+    "func": lambda js : round((js['gasmeter']['energy']['import']['price']['standingcharge'] or 0)+ \
+       ((js['gasmeter']['energy']['import']['day'] or 0) * (js['gasmeter']['energy']['import']['price']['unitrate'] or 0)), 2),
   }
 ]
 


### PR DESCRIPTION
- In cases where an IHD is configured for electricity meter only without a gas meter, the gas cost calculations would error

```
...
in <lambda>
    (js['gasmeter']['energy']['import']['day'] * js['gasmeter']['energy']['import']['price']['unitrate']), 2)
TypeError: unsupported operand type(s) for *: 'NoneType' and 'NoneType'
```

- This was due to the gas values being `null`
- We now default to `0` for any missing values

Test Plan:

- Manually run the calculation function on the following json sample

```json
{
    "gasmeter": {
        "timestamp": "1970-01-01T00:00:00Z",
        "energy": {
            "import": {
                "cumulative": null,
                "day": null,
                "week": null,
                "month": null,
                "units": "kWh",
                "cumulativevol": null,
                "cumulativevolunits": "",
                "dayvol": null,
                "weekvol": null,
                "monthvol": null,
                "dayweekmonthvolunits": "",
                "mprn": "read pending",
                "supplier": "---",
                "price": {
                    "unitrate": null,
                    "standingcharge": null
                }
            }
        }
    }
}
```