### PR TITLE
Added state_class 'TOTAL' to todays cost sensors

### DIFF
--- a/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
@@ -145,7 +145,7 @@ ELECTRICITY_SENSORS = [
     "name": "Smart Meter Electricity: Cost (Today)",
     "device_class": SensorDeviceClass.MONETARY,
     "unit_of_measurement": "GBP",
-    "state_class": None,
+    "state_class": SensorStateClass.TOTAL,
     "icon": "mdi:cash",
     "func": lambda js : round(js['electricitymeter']['energy']['import']['price']['standingcharge'] + \
        (js['electricitymeter']['energy']['import']['day'] * js['electricitymeter']['energy']['import']['price']['unitrate']), 2),
@@ -206,7 +206,7 @@ GAS_SENSORS = [
   {
     "name": "Smart Meter Gas: Import (This week)",
     "device_class": SensorDeviceClass.ENERGY,
-    "unit_of_measurement": ENERGY_KILO_WATT_HOUR, 
+    "unit_of_measurement": ENERGY_KILO_WATT_HOUR,
     "state_class": SensorStateClass.TOTAL_INCREASING,
     "icon": "mdi:fire",
     "func": lambda js : js['gasmeter']['energy']['import']['week']
@@ -250,7 +250,7 @@ GAS_SENSORS = [
     "name": "Smart Meter Gas: Cost (Today)",
     "device_class": SensorDeviceClass.MONETARY,
     "unit_of_measurement": "GBP",
-    "state_class": None,
+    "state_class": SensorStateClass.TOTAL,
     "icon": "mdi:cash",
     "func": lambda js : round((js['gasmeter']['energy']['import']['price']['standingcharge'] or 0)+ \
        ((js['gasmeter']['energy']['import']['day'] or 0) * (js['gasmeter']['energy']['import']['price']['unitrate'] or 0)), 2),
@@ -284,7 +284,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     await mqtt.async_subscribe(
         hass, data_topic, mqtt_message_received, 1
-    ) 
+    )
 
 
 
@@ -304,7 +304,7 @@ async def async_get_device_groups(deviceUpdateGroups, async_add_entities, device
         deviceUpdateGroups[device_id] = groups
 
     return deviceUpdateGroups[device_id]
-  
+
 
 class HildebrandGlowMqttSensorUpdateGroup:
     """Representation of Hildebrand Glow MQTT Meter Sensors that all get updated together."""
@@ -347,8 +347,8 @@ class HildebrandGlowMqttSensor(SensorEntity):
           self._attr_state_class = state_class
         self._attr_entity_category = entity_category
         self._attr_should_poll = False
-        
-        self._func = func        
+
+        self._func = func
         self._attr_device_info = DeviceInfo(
             connections={("mac", device_id)},
             manufacturer="Hildebrand Technology Limited",


### PR DESCRIPTION
This PR addresses #35 by adding `state_class` `SensorStateClass.TOTAL` to `Smart Meter Electricity: Cost (Today)` and `Smart Meter Gas: Cost (Today)` sensors.