### PR TITLE
add ihd status

### DIFF
--- a/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
@@ -54,7 +54,7 @@ STATE_SENSORS = [
     "func": lambda js: js["hardware"],
   },
   {
-    "name": "Smart Meter IHD Status",
+    "name": "Smart Meter IHD HAN Status",
     "device_class": None,
     "unit_of_measurement": None,
     "state_class": None,

--- a/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
@@ -54,6 +54,15 @@ STATE_SENSORS = [
     "func": lambda js: js["hardware"],
   },
   {
+    "name": "Smart Meter IHD Status",
+    "device_class": None,
+    "unit_of_measurement": None,
+    "state_class": None,
+    "entity_category": EntityCategory.DIAGNOSTIC,
+    "icon": "mdi:information-outline",
+    "func": lambda js: js["han"]["status"]
+  },
+  {
     "name": "Smart Meter IHD HAN RSSI",
     "device_class": SensorDeviceClass.SIGNAL_STRENGTH,
     "unit_of_measurement": SIGNAL_STRENGTH_DECIBELS,


### PR DESCRIPTION
the han status can change from `joined` to `service discovery` every so often
![Screenshot 2023-08-10 at 11-49-08 Logbook – Home Assistant(1)](https://github.com/megakid/ha_hildebrand_glow_ihd_mqtt/assets/765314/745f661e-435d-4243-974b-1888a86272d8)
