### PR TITLE
Add configuration options for meter time zone

### DIFF
--- a/custom_components/hildebrand_glow_ihd_mqtt/__init__.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/__init__.py
@@ -2,12 +2,15 @@
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_DEVICE_ID,
-)
+from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, CONF_TOPIC_PREFIX
+from .const import (
+    CONF_TIME_ZONE_ELECTRICITY,
+    CONF_TIME_ZONE_GAS,
+    CONF_TOPIC_PREFIX,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +32,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id][CONF_DEVICE_ID] = entry.data[CONF_DEVICE_ID].strip().upper().replace(":", "").replace(" ", "")
     hass.data[DOMAIN][entry.entry_id][CONF_TOPIC_PREFIX] = entry.data.get(CONF_TOPIC_PREFIX, "glow").strip().replace("#", "").replace(" ", "")
+    hass.data[DOMAIN][entry.entry_id][CONF_TIME_ZONE_ELECTRICITY] = entry.data.get(CONF_TIME_ZONE_ELECTRICITY)
+    hass.data[DOMAIN][entry.entry_id][CONF_TIME_ZONE_GAS] = entry.data.get(CONF_TIME_ZONE_GAS)
 
     for component in PLATFORMS:
         hass.async_create_task(

--- a/custom_components/hildebrand_glow_ihd_mqtt/__init__.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/__init__.py
@@ -9,6 +9,7 @@ from .const import (
     CONF_TIME_ZONE_ELECTRICITY,
     CONF_TIME_ZONE_GAS,
     CONF_TOPIC_PREFIX,
+    DEFAULT_TOPIC_PREFIX,
     DOMAIN,
 )
 
@@ -31,7 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN][entry.entry_id] = {}
 
     hass.data[DOMAIN][entry.entry_id][CONF_DEVICE_ID] = entry.data[CONF_DEVICE_ID].strip().upper().replace(":", "").replace(" ", "")
-    hass.data[DOMAIN][entry.entry_id][CONF_TOPIC_PREFIX] = entry.data.get(CONF_TOPIC_PREFIX, "glow").strip().replace("#", "").replace(" ", "")
+    hass.data[DOMAIN][entry.entry_id][CONF_TOPIC_PREFIX] = entry.data.get(CONF_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX).strip().replace("#", "").replace(" ", "")
     hass.data[DOMAIN][entry.entry_id][CONF_TIME_ZONE_ELECTRICITY] = entry.data.get(CONF_TIME_ZONE_ELECTRICITY)
     hass.data[DOMAIN][entry.entry_id][CONF_TIME_ZONE_GAS] = entry.data.get(CONF_TIME_ZONE_GAS)
 

--- a/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
@@ -1,44 +1,79 @@
 """Config flow for Hildebrand Glow IHD MQTT."""
 import logging
-
 import voluptuous as vol
+import zoneinfo
 
-from homeassistant import config_entries
+from homeassistant.config_entries import (
+    ConfigFlow,
+    ConfigEntry,
+    OptionsFlow,
+    CONN_CLASS_LOCAL_PUSH,
+)
 from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
-from .const import DOMAIN, CONF_TOPIC_PREFIX
+from .const import (
+    CONF_TIME_ZONE_ELECTRICITY,
+    CONF_TIME_ZONE_GAS,
+    CONF_TOPIC_PREFIX,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-class HildebrandGlowIHDMQTTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class HildebrandGlowIHDMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
-
+    MINOR_VERSION = 1
+    CONNECTION_CLASS = CONN_CLASS_LOCAL_PUSH
+    
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=vol.Schema({
-                    vol.Required(CONF_DEVICE_ID, default='+'):str,
-                    vol.Required(CONF_TOPIC_PREFIX, default='glow'):str
-                }), errors=errors
+
+        if user_input is not None:
+            device_id = user_input.get(CONF_DEVICE_ID)
+            topic_prefix = user_input.get(CONF_TOPIC_PREFIX)
+            time_zone_electricity = user_input.get(CONF_TIME_ZONE_ELECTRICITY)
+            time_zone_gas = user_input.get(CONF_TIME_ZONE_GAS)
+
+            await self.async_set_unique_id('{}_{}'.format(DOMAIN, device_id))
+            self._abort_if_unique_id_configured()
+
+            return self.async_create_entry(
+                title="",
+                data={
+                    CONF_DEVICE_ID: device_id,
+                    CONF_TOPIC_PREFIX: topic_prefix,
+                    CONF_TIME_ZONE_ELECTRICITY: time_zone_electricity,
+                    CONF_TIME_ZONE_GAS: time_zone_gas,
+                })
+
+        get_timezones: list[str] = list(
+            await self.hass.async_add_executor_job(
+                zoneinfo.available_timezones
             )
-
-        device_id = user_input[CONF_DEVICE_ID]
-        topic_prefix = user_input[CONF_TOPIC_PREFIX]
-
-        await self.async_set_unique_id('{}_{}'.format(DOMAIN, device_id))
-        self._abort_if_unique_id_configured()
-
-        return self.async_create_entry(
-            title="",
-            data={
-                CONF_DEVICE_ID: device_id,
-                CONF_TOPIC_PREFIX: topic_prefix
-            })
-
+        )
+        return self.async_show_form(
+            step_id="user", data_schema=vol.Schema({
+                vol.Required(CONF_DEVICE_ID, default='+'):str,
+                vol.Required(CONF_TOPIC_PREFIX, default='glow'):str,
+                vol.Optional(CONF_TIME_ZONE_ELECTRICITY): SelectSelector(
+                    SelectSelectorConfig(
+                        options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
+                    )
+                ),
+                vol.Optional(CONF_TIME_ZONE_GAS): SelectSelector(
+                    SelectSelectorConfig(
+                        options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
+                    )
+                ),
+            }), errors=errors
+        )
 
     @staticmethod
     @callback
@@ -47,10 +82,10 @@ class HildebrandGlowIHDMQTTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return HildebrandGlowIHDMQTTOptionsFlowHandler(config_entry)
 
 
-class HildebrandGlowIHDMQTTOptionsFlowHandler(config_entries.OptionsFlow):
+class HildebrandGlowIHDMQTTOptionsFlowHandler(OptionsFlow):
     """Handle a option flow for HildebrandGlowIHDMQTT."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
         self.config_entry = config_entry
 
@@ -59,8 +94,23 @@ class HildebrandGlowIHDMQTTOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
+        get_timezones: list[str] = list(
+            await self.hass.async_add_executor_job(
+                zoneinfo.available_timezones
+            )
+        )
         data_schema=vol.Schema({
-            vol.Required(CONF_DEVICE_ID, default=self.config_entry.options.get(CONF_DEVICE_ID, "+")):str,
-            vol.Required(CONF_TOPIC_PREFIX, default=self.config_entry.options.get(CONF_TOPIC_PREFIX, "glow")):str
+            vol.Required(CONF_DEVICE_ID, default='+'):str,
+            vol.Required(CONF_TOPIC_PREFIX, default='glow'):str,
+            vol.Optional(CONF_TIME_ZONE_ELECTRICITY): SelectSelector(
+                SelectSelectorConfig(
+                    options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
+                )
+            ),
+            vol.Optional(CONF_TIME_ZONE_GAS): SelectSelector(
+                SelectSelectorConfig(
+                    options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
+                )
+            ),
         })
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
@@ -6,8 +6,8 @@ import zoneinfo
 from homeassistant.config_entries import (
     ConfigFlow,
     ConfigEntry,
-    OptionsFlow,
     CONN_CLASS_LOCAL_PUSH,
+    OptionsFlow,
 )
 from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import callback
@@ -21,6 +21,8 @@ from .const import (
     CONF_TIME_ZONE_ELECTRICITY,
     CONF_TIME_ZONE_GAS,
     CONF_TOPIC_PREFIX,
+    DEFAULT_DEVICE_ID,
+    DEFAULT_TOPIC_PREFIX,
     DOMAIN,
 )
 
@@ -60,14 +62,14 @@ class HildebrandGlowIHDMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         return self.async_show_form(
             step_id="user", data_schema=vol.Schema({
-                vol.Required(CONF_DEVICE_ID, default='+'):str,
-                vol.Required(CONF_TOPIC_PREFIX, default='glow'):str,
-                vol.Optional(CONF_TIME_ZONE_ELECTRICITY): SelectSelector(
+                vol.Required(CONF_DEVICE_ID, default=DEFAULT_DEVICE_ID):str,
+                vol.Required(CONF_TOPIC_PREFIX, default=DEFAULT_TOPIC_PREFIX):str,
+                vol.Required(CONF_TIME_ZONE_ELECTRICITY, default=self.hass.config.time_zone): SelectSelector(
                     SelectSelectorConfig(
                         options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
                     )
                 ),
-                vol.Optional(CONF_TIME_ZONE_GAS): SelectSelector(
+                vol.Required(CONF_TIME_ZONE_GAS, default=self.hass.config.time_zone): SelectSelector(
                     SelectSelectorConfig(
                         options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
                     )
@@ -100,14 +102,14 @@ class HildebrandGlowIHDMQTTOptionsFlowHandler(OptionsFlow):
             )
         )
         data_schema=vol.Schema({
-            vol.Required(CONF_DEVICE_ID, default='+'):str,
-            vol.Required(CONF_TOPIC_PREFIX, default='glow'):str,
-            vol.Optional(CONF_TIME_ZONE_ELECTRICITY): SelectSelector(
+            vol.Required(CONF_DEVICE_ID, default=self.config_entry.options.get(CONF_DEVICE_ID, DEFAULT_DEVICE_ID)):str,
+            vol.Required(CONF_TOPIC_PREFIX, default=self.config_entry.options.get(CONF_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX)):str,
+            vol.Required(CONF_TIME_ZONE_ELECTRICITY, default=self.config_entry.options.get(CONF_TIME_ZONE_ELECTRICITY, self.hass.config.time_zone)): SelectSelector(
                 SelectSelectorConfig(
                     options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
                 )
             ),
-            vol.Optional(CONF_TIME_ZONE_GAS): SelectSelector(
+            vol.Required(CONF_TIME_ZONE_GAS, default=self.config_entry.options.get(CONF_TIME_ZONE_GAS, self.hass.config.time_zone)): SelectSelector(
                 SelectSelectorConfig(
                     options=get_timezones, mode=SelectSelectorMode.DROPDOWN, sort=True
                 )

--- a/custom_components/hildebrand_glow_ihd_mqtt/const.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/const.py
@@ -1,5 +1,6 @@
 from itertools import cycle, islice
 from typing import Final
+from enum import Enum
 
 DOMAIN: Final = "hildebrand_glow_ihd"
 
@@ -14,4 +15,15 @@ ATTR_LAST_ERROR = "last_error"
 ATTR_ERROR = "error"
 ATTR_STATE = "state"
 
+CONF_TIME_ZONE_ELECTRICITY = "time_zone_electricity"
+CONF_TIME_ZONE_GAS = "time_zone_gas"
 CONF_TOPIC_PREFIX = "topic_prefix"
+
+# Meter intervals
+class MeterInterval(Enum):
+    """Meter intervals."""
+
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+    YEAR = "year"

--- a/custom_components/hildebrand_glow_ihd_mqtt/const.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/const.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 DOMAIN: Final = "hildebrand_glow_ihd"
 
+
 ATTR_NAME = "name"
 ATTR_ACTIVITY = "activity"
 ATTR_BATTERY_STATE = "battery_state"
@@ -18,6 +19,9 @@ ATTR_STATE = "state"
 CONF_TIME_ZONE_ELECTRICITY = "time_zone_electricity"
 CONF_TIME_ZONE_GAS = "time_zone_gas"
 CONF_TOPIC_PREFIX = "topic_prefix"
+
+DEFAULT_DEVICE_ID = "+"
+DEFAULT_TOPIC_PREFIX= "glow"
 
 # Meter intervals
 class MeterInterval(Enum):

--- a/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
@@ -32,6 +32,8 @@ from .const import (
     CONF_TIME_ZONE_ELECTRICITY,
     CONF_TIME_ZONE_GAS,
     CONF_TOPIC_PREFIX,
+    DEFAULT_DEVICE_ID,
+    DEFAULT_TOPIC_PREFIX,
     DOMAIN,
     MeterInterval,
 )
@@ -300,7 +302,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     # the config is defaulted to + which happens to mean we will subscribe to all devices
     device_mac = hass.data[DOMAIN][config_entry.entry_id][CONF_DEVICE_ID]
-    topic_prefix = hass.data[DOMAIN][config_entry.entry_id][CONF_TOPIC_PREFIX] or "glow"
+    topic_prefix = hass.data[DOMAIN][config_entry.entry_id][CONF_TOPIC_PREFIX] or DEFAULT_TOPIC_PREFIX
     time_zone_electricity = hass.data[DOMAIN][config_entry.entry_id][
         CONF_TIME_ZONE_ELECTRICITY
     ]
@@ -314,7 +316,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         topic = message.topic
         payload = message.payload
         device_id = topic.split("/")[1]
-        if device_mac == "+" or device_id == device_mac:
+        if device_mac == DEFAULT_DEVICE_ID or device_id == device_mac:
             updateGroups = await async_get_device_groups(
                 deviceUpdateGroups,
                 async_add_entities,

--- a/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
@@ -1,11 +1,13 @@
 """Support for hildebrand glow MQTT sensors."""
 
 from __future__ import annotations
+from datetime import datetime, time, timedelta, tzinfo
 from enum import Enum
 import json
-import re
 import logging
+import re
 from typing import Iterable
+from zoneinfo import ZoneInfo
 
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt.models import ReceiveMessage
@@ -14,35 +16,31 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
-from .const import DOMAIN, CONF_TOPIC_PREFIX
 from homeassistant.const import (
-    CONF_DEVICE_ID,
     ATTR_DEVICE_ID,
-    UnitOfEnergy,
-    UnitOfVolume,
-    UnitOfPower,
+    CONF_DEVICE_ID,
     SIGNAL_STRENGTH_DECIBELS,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfVolume,
 )
 from homeassistant.core import callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.util import slugify
-from datetime import datetime, time, timedelta
-from zoneinfo import ZoneInfo
+
+from .const import (
+    CONF_TIME_ZONE_ELECTRICITY,
+    CONF_TIME_ZONE_GAS,
+    CONF_TOPIC_PREFIX,
+    DOMAIN,
+    MeterInterval,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 # glow/XXXXXXYYYYYY/STATE                   {"software":"v1.8.12","timestamp":"2022-06-11T20:54:53Z","hardware":"GLOW-IHD-01-1v4-SMETS2","ethmac":"1234567890AB","smetsversion":"SMETS2","eui":"12:34:56:78:91:23:45","zigbee":"1.2.5","han":{"rssi":-75,"status":"joined","lqi":100}}
 # glow/XXXXXXYYYYYY/SENSOR/electricitymeter {"electricitymeter":{"timestamp":"2022-06-11T20:38:00Z","energy":{"export":{"cumulative":0.000,"units":"kWh"},"import":{"cumulative":6613.405,"day":13.252,"week":141.710,"month":293.598,"units":"kWh","mpan":"1234","supplier":"ABC ENERGY","price":{"unitrate":0.04998,"standingcharge":0.24030}}},"power":{"value":0.951,"units":"kW"}}}
 # glow/XXXXXXYYYYYY/SENSOR/gasmeter         {"gasmeter":{"timestamp":"2022-06-11T20:53:52Z","energy":{"export":{"cumulative":0.000,"units":"kWh"},"import":{"cumulative":17940.852,"day":11.128,"week":104.749,"month":217.122,"units":"kWh","mprn":"1234","supplier":"---","price":{"unitrate":0.07320,"standingcharge":0.17850}}},"power":{"value":0.000,"units":"kW"}}}
-
-
-class Interval(Enum):
-    DAY = "day"
-    WEEK = "week"
-    MONTH = "month"
-    NONE = None
-
 
 STATE_SENSORS = [
     {
@@ -170,7 +168,7 @@ ELECTRICITY_SENSORS = [
         "unit_of_measurement": "GBP",
         "state_class": SensorStateClass.TOTAL,
         "icon": "mdi:cash",
-        "reset_interval": Interval.DAY,
+        "meter_interval": MeterInterval.DAY,
         "func": lambda js: round(
             js["electricitymeter"]["energy"]["import"]["price"]["standingcharge"]
             + (
@@ -284,7 +282,7 @@ GAS_SENSORS = [
         "unit_of_measurement": "GBP",
         "state_class": SensorStateClass.TOTAL,
         "icon": "mdi:cash",
-        "reset_interval": Interval.DAY,
+        "meter_interval": MeterInterval.DAY,
         "func": lambda js: round(
             (js["gasmeter"]["energy"]["import"]["price"]["standingcharge"] or 0)
             + (
@@ -303,6 +301,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     # the config is defaulted to + which happens to mean we will subscribe to all devices
     device_mac = hass.data[DOMAIN][config_entry.entry_id][CONF_DEVICE_ID]
     topic_prefix = hass.data[DOMAIN][config_entry.entry_id][CONF_TOPIC_PREFIX] or "glow"
+    time_zone_electricity = hass.data[DOMAIN][config_entry.entry_id][
+        CONF_TIME_ZONE_ELECTRICITY
+    ]
+    time_zone_gas = hass.data[DOMAIN][config_entry.entry_id][CONF_TIME_ZONE_GAS]
 
     deviceUpdateGroups = {}
 
@@ -314,7 +316,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         device_id = topic.split("/")[1]
         if device_mac == "+" or device_id == device_mac:
             updateGroups = await async_get_device_groups(
-                deviceUpdateGroups, async_add_entities, device_id
+                deviceUpdateGroups,
+                async_add_entities,
+                device_id,
+                time_zone_electricity,
+                time_zone_gas,
             )
             _LOGGER.debug("Received message: %s", topic)
             _LOGGER.debug("  Payload: %s", payload)
@@ -326,16 +332,27 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     await mqtt.async_subscribe(hass, data_topic, mqtt_message_received, 1)
 
 
-async def async_get_device_groups(deviceUpdateGroups, async_add_entities, device_id):
+async def async_get_device_groups(
+    deviceUpdateGroups,
+    async_add_entities,
+    device_id,
+    time_zone_electricity,
+    time_zone_gas,
+):
     # add to update groups if not already there
     if device_id not in deviceUpdateGroups:
         _LOGGER.debug("New device found: %s", device_id)
         groups = [
             HildebrandGlowMqttSensorUpdateGroup(device_id, "STATE", STATE_SENSORS),
             HildebrandGlowMqttSensorUpdateGroup(
-                device_id, "electricitymeter", ELECTRICITY_SENSORS
+                device_id,
+                "electricitymeter",
+                ELECTRICITY_SENSORS,
+                time_zone_electricity,
             ),
-            HildebrandGlowMqttSensorUpdateGroup(device_id, "gasmeter", GAS_SENSORS),
+            HildebrandGlowMqttSensorUpdateGroup(
+                device_id, "gasmeter", GAS_SENSORS, time_zone_gas
+            ),
         ]
         async_add_entities(
             [
@@ -353,11 +370,14 @@ async def async_get_device_groups(deviceUpdateGroups, async_add_entities, device
 class HildebrandGlowMqttSensorUpdateGroup:
     """Representation of Hildebrand Glow MQTT Meter Sensors that all get updated together."""
 
-    def __init__(self, device_id: str, topic_regex: str, meters: Iterable) -> None:
+    def __init__(
+        self, device_id: str, topic_regex: str, meters: Iterable, time_zone: str | None = None
+    ) -> None:
         """Initialize the sensor collection."""
         self._topic_regex = re.compile(topic_regex)
         self._sensors = [
-            HildebrandGlowMqttSensor(device_id=device_id, **meter) for meter in meters
+            HildebrandGlowMqttSensor(device_id=device_id, time_zone=time_zone, **meter)
+            for meter in meters
         ]
 
     def process_update(self, message: ReceiveMessage) -> None:
@@ -382,6 +402,7 @@ class HildebrandGlowMqttSensor(SensorEntity):
     def __init__(
         self,
         device_id,
+        time_zone,
         name,
         icon,
         device_class,
@@ -390,14 +411,12 @@ class HildebrandGlowMqttSensor(SensorEntity):
         func,
         entity_category=None,
         ignore_zero_values=False,
-        reset_interval: Interval = None,
+        meter_interval: MeterInterval | None = None,
     ) -> None:
         """Initialize the sensor."""
         self._device_id = device_id
-        self._ignore_zero_values = ignore_zero_values
-        self._reset_interval = reset_interval
+        self._time_zone = time_zone
         self._attr_name = name
-        self._attr_unique_id = slugify(device_id + "_" + name)
         self._attr_icon = icon
         if device_class:
             self._attr_device_class = device_class
@@ -405,10 +424,12 @@ class HildebrandGlowMqttSensor(SensorEntity):
             self._attr_native_unit_of_measurement = unit_of_measurement
         if state_class:
             self._attr_state_class = state_class
-        self._attr_entity_category = entity_category
+        self._attr_unique_id = slugify(device_id + "_" + name)
         self._attr_should_poll = False
-
         self._func = func
+        self._attr_entity_category = entity_category
+        self._ignore_zero_values = ignore_zero_values
+        self._meter_interval = meter_interval
         self._attr_device_info = DeviceInfo(
             connections={("mac", device_id)},
             manufacturer="Hildebrand Technology Limited",
@@ -416,24 +437,31 @@ class HildebrandGlowMqttSensor(SensorEntity):
             name=f"Glow Smart Meter {device_id}",
         )
         self._attr_native_value = None
-        if state_class == SensorStateClass.TOTAL and reset_interval:
+        if state_class == SensorStateClass.TOTAL and meter_interval:
             self._attr_last_reset = None
             self._last_reset_reported = True
 
-    def determine_last_reset(self, message_datetime: datetime) -> datetime:
-        """Return midnight of the reset interval in UTC time zone."""
-        midnight = datetime.combine(
-            message_datetime.date(), time.min, message_datetime.tzinfo
+    @staticmethod
+    def determine_last_reset(
+        message_datetime: datetime, meter_timezone: tzinfo, meter_interval: MeterInterval
+    ) -> datetime:
+        """Return midnight of the meter's reset interval in UTC."""
+        meter_datetime = message_datetime.astimezone(meter_timezone)
+        meter_midnight = datetime.combine(
+            meter_datetime.date(), time.min, meter_datetime.tzinfo
         )
-        if self._reset_interval == Interval.DAY:
-            last_reset = midnight
-        elif self._reset_interval == Interval.WEEK:
-            last_reset = midnight - timedelta(days=midnight.weekday())
-        elif self._reset_interval == Interval.MONTH:
-            last_reset = midnight.replace(day=1)
+        if meter_interval == MeterInterval.DAY:
+            last_reset = meter_midnight
+        elif meter_interval == MeterInterval.WEEK:
+            last_reset = meter_midnight - timedelta(days=meter_midnight.weekday())
+        elif meter_interval == MeterInterval.MONTH:
+            last_reset = meter_midnight.replace(day=1)
+        elif meter_interval == MeterInterval.YEAR:
+            last_reset = meter_midnight.replace(day=1, month=1)
         return last_reset.astimezone(ZoneInfo("UTC"))
 
-    def get_message_datetime(self, mqtt_data) -> datetime:
+    @staticmethod
+    def get_message_datetime(mqtt_data) -> datetime:
         """Return the message timestamp as a datetime."""
         timestamp = (
             mqtt_data.get("timestamp")
@@ -455,9 +483,11 @@ class HildebrandGlowMqttSensor(SensorEntity):
             return
         self._attr_native_value = new_value
 
-        if self._last_reset_reported and self._reset_interval:
+        if self._last_reset_reported and self._meter_interval:
             self._attr_last_reset = self.determine_last_reset(
-                self.get_message_datetime(mqtt_data)
+                self.get_message_datetime(mqtt_data),
+                ZoneInfo(self._time_zone or self.hass.config.time_zone),
+                self._meter_interval
             )
 
         if (

--- a/custom_components/hildebrand_glow_ihd_mqtt/strings.json
+++ b/custom_components/hildebrand_glow_ihd_mqtt/strings.json
@@ -15,8 +15,8 @@
         "data": {
           "device_id": "Device Id (leave as + to auto-detect all devices on your MQTT)",
           "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)",
-          "time_zone_electricity": "Time zone that the electrity meter uses for its cycle.",
-          "time_zone_gas": "Time zone that the gas meter uses for its cycle."
+          "time_zone_electricity": "Time zone that the electrity meter uses.",
+          "time_zone_gas": "Time zone that the gas meter uses."
         },
         "title": "Hildebrand Glow IHD Local MQTT"
       }
@@ -29,8 +29,8 @@
         "data": {
           "device_id": "Device Id (leave as + to auto-detect all devices on your MQTT)",
           "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)",
-          "time_zone_electricity": "Time zone that the electrity meter uses for its cycle.",
-          "time_zone_gas": "Time zone that the gas meter uses for its cycle."
+          "time_zone_electricity": "Time zone that the electrity meter uses.",
+          "time_zone_gas": "Time zone that the gas meter uses."
         },
         "title": "Hildebrand Glow IHD Local MQTT"
       }

--- a/custom_components/hildebrand_glow_ihd_mqtt/strings.json
+++ b/custom_components/hildebrand_glow_ihd_mqtt/strings.json
@@ -14,7 +14,9 @@
         "description": "Configuring Hildebrand Glow IHD Local MQTT.",
         "data": {
           "device_id": "Device Id (leave as + to auto-detect all devices on your MQTT)",
-          "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)"
+          "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)",
+          "time_zone_electricity": "Time zone that the electrity meter uses for its cycle.",
+          "time_zone_gas": "Time zone that the gas meter uses for its cycle."
         },
         "title": "Hildebrand Glow IHD Local MQTT"
       }
@@ -26,7 +28,9 @@
         "description": "Configuring Hildebrand Glow IHD Local MQTT.",
         "data": {
           "device_id": "Device Id (leave as + to auto-detect all devices on your MQTT)",
-          "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)"
+          "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)",
+          "time_zone_electricity": "Time zone that the electrity meter uses for its cycle.",
+          "time_zone_gas": "Time zone that the gas meter uses for its cycle."
         },
         "title": "Hildebrand Glow IHD Local MQTT"
       }

--- a/custom_components/hildebrand_glow_ihd_mqtt/translations/en.json
+++ b/custom_components/hildebrand_glow_ihd_mqtt/translations/en.json
@@ -15,8 +15,8 @@
         "data": {
           "device_id": "Device Id (leave as + to auto-detect all devices on your MQTT)",
           "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)",
-          "time_zone_electricity": "Time zone that the electrity meter uses for its cycle.",
-          "time_zone_gas": "Time zone that the gas meter uses for its cycle."
+          "time_zone_electricity": "Time zone that the electrity meter uses.",
+          "time_zone_gas": "Time zone that the gas meter uses."
         },
         "title": "Hildebrand Glow IHD Local MQTT"
       }
@@ -29,8 +29,8 @@
         "data": {
           "device_id": "Device Id (leave as + to auto-detect all devices on your MQTT)",
           "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)",
-          "time_zone_electricity": "Time zone that the electrity meter uses for its cycle.",
-          "time_zone_gas": "Time zone that the gas meter uses for its cycle."
+          "time_zone_electricity": "Time zone that the electrity meter uses.",
+          "time_zone_gas": "Time zone that the gas meter uses."
         },
         "title": "Hildebrand Glow IHD Local MQTT"
       }

--- a/custom_components/hildebrand_glow_ihd_mqtt/translations/en.json
+++ b/custom_components/hildebrand_glow_ihd_mqtt/translations/en.json
@@ -14,7 +14,9 @@
         "description": "Configuring Hildebrand Glow IHD Local MQTT.",
         "data": {
           "device_id": "Device Id (leave as + to auto-detect all devices on your MQTT)",
-          "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)"
+          "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)",
+          "time_zone_electricity": "Time zone that the electrity meter uses for its cycle.",
+          "time_zone_gas": "Time zone that the gas meter uses for its cycle."
         },
         "title": "Hildebrand Glow IHD Local MQTT"
       }
@@ -26,7 +28,9 @@
         "description": "Configuring Hildebrand Glow IHD Local MQTT.",
         "data": {
           "device_id": "Device Id (leave as + to auto-detect all devices on your MQTT)",
-          "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)"
+          "topic_prefix": "Topic Prefix (leaving as 'glow' is usually the right thing to do!)",
+          "time_zone_electricity": "Time zone that the electrity meter uses for its cycle.",
+          "time_zone_gas": "Time zone that the gas meter uses for its cycle."
         },
         "title": "Hildebrand Glow IHD Local MQTT"
       }


### PR DESCRIPTION
Addresses the observations discussed in https://github.com/megakid/ha_hildebrand_glow_ihd_mqtt/pull/58 where some suppliers configure meters to reset totals on UTC rather than local time respective of DST, this is required to provide home assistant with correct last_reset times.

This is handled by two new config parameters which by default will use the local time respective of DST:

- Electricity meter time zone
- Gas meter time zone
