### PR TITLE
Options flow fix & min version bump

### DIFF
--- a/custom_components/hildebrand_glow_ihd_mqtt/__init__.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/__init__.py
@@ -1,8 +1,9 @@
 """The hildebrand_glow_ihd_mqtt component."""
 import logging
 
+from awesomeversion.awesomeversion import AwesomeVersion
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_DEVICE_ID
+from homeassistant.const import __version__ as HA_VERSION, CONF_DEVICE_ID  # noqa: N812
 from homeassistant.core import HomeAssistant
 
 from .const import (
@@ -11,6 +12,7 @@ from .const import (
     CONF_TOPIC_PREFIX,
     DEFAULT_TOPIC_PREFIX,
     DOMAIN,
+    MIN_HA_VERSION,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,6 +21,15 @@ PLATFORMS = ["sensor"]
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Hildebrand Glow IHD MQTT integration."""
+
+    if AwesomeVersion(HA_VERSION) < AwesomeVersion(MIN_HA_VERSION):  # pragma: no cover
+        msg = (
+            "This integration requires at least HomeAssistant version "
+            f" {MIN_HA_VERSION}, you are running version {HA_VERSION}."
+            " Please upgrade HomeAssistant to continue use of this integration."
+        )
+        _LOGGER.critical(msg)
+        return False
 
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}

--- a/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
@@ -77,19 +77,9 @@ class HildebrandGlowIHDMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
             }), errors=errors
         )
 
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Get the options flow for this handler."""
-        return HildebrandGlowIHDMQTTOptionsFlowHandler(config_entry)
-
 
 class HildebrandGlowIHDMQTTOptionsFlowHandler(OptionsFlow):
     """Handle a option flow for HildebrandGlowIHDMQTT."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""

--- a/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import (
     OptionsFlow,
 )
 from homeassistant.const import CONF_DEVICE_ID
+from homeassistant.core import callback
 from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
@@ -75,6 +76,11 @@ class HildebrandGlowIHDMQTTConfigFlow(ConfigFlow, domain=DOMAIN):
             }), errors=errors
         )
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return HildebrandGlowIHDMQTTOptionsFlowHandler()
 
 class HildebrandGlowIHDMQTTOptionsFlowHandler(OptionsFlow):
     """Handle a option flow for HildebrandGlowIHDMQTT."""

--- a/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/config_flow.py
@@ -5,12 +5,10 @@ import zoneinfo
 
 from homeassistant.config_entries import (
     ConfigFlow,
-    ConfigEntry,
     CONN_CLASS_LOCAL_PUSH,
     OptionsFlow,
 )
 from homeassistant.const import CONF_DEVICE_ID
-from homeassistant.core import callback
 from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,

--- a/custom_components/hildebrand_glow_ihd_mqtt/const.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/const.py
@@ -3,7 +3,7 @@ from typing import Final
 from enum import Enum
 
 DOMAIN: Final = "hildebrand_glow_ihd"
-
+MIN_HA_VERSION = "2024.12"
 
 ATTR_NAME = "name"
 ATTR_ACTIVITY = "activity"

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
     "render_readme": true,
     "domains": ["sensor"],
     "country": ["GB"],
-    "homeassistant": "2021.9.0"
+    "homeassistant": "2024.12.0"
 }


### PR DESCRIPTION
With Home Assistant 2024.12 they have changed the options flow handler and deprecated the way it works currently.
If you open Configure on the device it will issue a warning in the log (due to be removed 2025.12).

This PR changes it to the new method, bumps the min version and also adds some checking to throw a message if the min version is not high enough. I use this checking in my own custom integrations and have seen it used elsewhere so a fairly established pattern.

Fixes #69 