### PR TITLE
Force updates of the import current power

### DIFF
--- a/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
+++ b/custom_components/hildebrand_glow_ihd_mqtt/sensor.py
@@ -163,6 +163,7 @@ ELECTRICITY_SENSORS = [
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": "mdi:flash",
         "func": lambda js: js["electricitymeter"]["power"]["value"],
+        "force_update": True,
     },
     {
         "name": "Smart Meter Electricity: Cost (Today)",
@@ -414,6 +415,7 @@ class HildebrandGlowMqttSensor(SensorEntity):
         entity_category=None,
         ignore_zero_values=False,
         meter_interval: MeterInterval | None = None,
+        force_update=False,
     ) -> None:
         """Initialize the sensor."""
         self._device_id = device_id
@@ -432,6 +434,7 @@ class HildebrandGlowMqttSensor(SensorEntity):
         self._attr_entity_category = entity_category
         self._ignore_zero_values = ignore_zero_values
         self._meter_interval = meter_interval
+        self._attr_force_update = force_update
         self._attr_device_info = DeviceInfo(
             connections={("mac", device_id)},
             manufacturer="Hildebrand Technology Limited",


### PR DESCRIPTION
Home Assistant made a change a while back to not store duplicate entity state values in the DB by default.  This reduces the amount of load and storage requirements, but makes graphing changes of the entities state difficult, as can be big gaps in the data.  I have a solar array, when its producing the import power readings can be 0w for extended periods of time, which causes misleading ramps to be displayed in ApexCharts.

This MR makes updates to the electricity import power always write to the database, so they can be easily graphed at a later date. 